### PR TITLE
Handle overflow problem reported in #23

### DIFF
--- a/src/mapi_attr.c
+++ b/src/mapi_attr.c
@@ -211,6 +211,8 @@ mapi_attr_read (size_t len, unsigned char *buf)
 		    CHECKINT32(idx, len); a->names[i].len = GETINT32(buf+idx); idx += 4;
 
 		    /* read the data into a buffer */
+                    /* read the data into a buffer */
+                    assert(a->names[i].len != 0);
                     assert(idx+a->names[i].len <= len);
 		    a->names[i].data = unicode_to_utf8(a->names[i].len, buf+idx);
 		    

--- a/src/util.c
+++ b/src/util.c
@@ -85,28 +85,29 @@ unicode_to_utf8 (size_t len, unsigned char* buf)
     int j = 0;
     unsigned char *utf8 = malloc (3 * len/2 + 1); /* won't get any longer than this */
 
-    for (i = 0; i < len - 1; i += 2)
-    {
-	uint32 c = GETINT16(buf + i);
-	if (c <= 0x007f)
-	{
-	    utf8[j++] = 0x00 | ((c & 0x007f) >> 0);
-	}
-	else if (c < 0x07ff)
-	{
-	    utf8[j++] = 0xc0 | ((c & 0x07c0) >> 6);
-	    utf8[j++] = 0x80 | ((c & 0x003f) >> 0);
-	}
-	else
-	{
-	    utf8[j++] = 0xe0 | ((c & 0xf000) >> 12);
-	    utf8[j++] = 0x80 | ((c & 0x0fc0) >> 6);
-	    utf8[j++] = 0x80 | ((c & 0x003f) >> 0);
-	}
+    if (len > 0) {
+        for (i = 0; i < len - 1; i += 2)
+        {
+            uint32 c = GETINT16(buf + i);
+            if (c <= 0x007f)
+            {
+                utf8[j++] = 0x00 | ((c & 0x007f) >> 0);
+            }
+            else if (c < 0x07ff)
+            {
+                utf8[j++] = 0xc0 | ((c & 0x07c0) >> 6);
+                utf8[j++] = 0x80 | ((c & 0x003f) >> 0);
+            }
+            else
+            {
+                utf8[j++] = 0xe0 | ((c & 0xf000) >> 12);
+                utf8[j++] = 0x80 | ((c & 0x0fc0) >> 6);
+                utf8[j++] = 0x80 | ((c & 0x003f) >> 0);
+            }
+        }
     }
-    
+
     utf8[j] = '\0';
-    
+
     return utf8;
 }
-


### PR DESCRIPTION
1. Assert that names must be non-zero length.
2. Keep unicode_to_utf8 from underflowing.