### PR TITLE
fix strdup() on possibly unterminated string

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -106,29 +106,31 @@ checked_xmalloc (size_t num, size_t size)
 
 /* xmallocs memory and clears it out */
 void*
-xcalloc (size_t num, size_t size)
+xcalloc (size_t num, size_t size, size_t extra)
 {
     size_t res;
     if (check_mul_overflow(num, size, &res))
         abort();
 
     void *ptr;
-    ptr = malloc(res);
+    if (res + extra < res)
+        abort();
+    ptr = malloc(res + extra);
     if (ptr)
     {
-        memset (ptr, '\0', (res));
+        memset (ptr, '\0', (res + extra));
     }
     return ptr;
 }
 
 /* xcallocs memory but only up to a limit */
 void*
-checked_xcalloc (size_t num, size_t size)
+checked_xcalloc (size_t num, size_t size, size_t extra)
 {
     size_t res;
     if (check_mul_overflow(num, size, &res))
         abort();
 
     alloc_limit_assert ("checked_xcalloc", (res));
-    return xcalloc (num, size);
+    return xcalloc (num, size, extra);
 }

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -76,13 +76,14 @@ alloc_limit_assert (char *fn_name, size_t size)
 
 /* attempts to malloc memory, if fails print error and call abort */
 void*
-xmalloc (size_t num, size_t size)
+xmalloc (size_t num, size_t size, size_t extra)
 {
     size_t res;
     if (check_mul_overflow(num, size, &res))
         abort();
-
-    void *ptr = malloc (res);
+    if (res + extra < res)
+        abort();
+    void *ptr = malloc (res + extra);
     if (!ptr
         && (size != 0))         /* some libc don't like size == 0 */
     {
@@ -94,14 +95,15 @@ xmalloc (size_t num, size_t size)
 
 /* Allocates memory but only up to a limit */
 void*
-checked_xmalloc (size_t num, size_t size)
+checked_xmalloc (size_t num, size_t size, size_t extra)
 {
     size_t res;
     if (check_mul_overflow(num, size, &res))
         abort();
-
+    if (res + extra < res)
+        abort();
     alloc_limit_assert ("checked_xmalloc", res);
-    return xmalloc (num, size);
+    return xmalloc (num, size, extra);
 }
 
 /* xmallocs memory and clears it out */

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -37,17 +37,19 @@ extern size_t get_alloc_limit();
 extern void alloc_limit_assert (char *fn_name, size_t size);
 extern void* checked_xmalloc (size_t num, size_t size);
 extern void* xmalloc (size_t num, size_t size);
-extern void* checked_xcalloc (size_t num, size_t size);
-extern void* xcalloc (size_t num, size_t size);
+extern void* checked_xcalloc (size_t num, size_t size, size_t extra);
+extern void* xcalloc (size_t num, size_t size, size_t extra);
 
 #define XMALLOC(_type,_num)			                \
         ((_type*)xmalloc((_num), sizeof(_type)))
 #define XCALLOC(_type,_num) 				        \
-        ((_type*)xcalloc((_num), sizeof (_type)))
+  ((_type*)xcalloc((_num), sizeof (_type), 0))
 #define CHECKED_XMALLOC(_type,_num) 			        \
         ((_type*)checked_xmalloc((_num),sizeof(_type)))
-#define CHECKED_XCALLOC(_type,_num) 			        \
-        ((_type*)checked_xcalloc((_num),sizeof(_type)))
+#define CHECKED_XCALLOC(_type,_num)			\
+  ((_type*)checked_xcalloc((_num),sizeof(_type),0))
+#define CHECKED_XCALLOC_ADDNULL(_type,_num)		\
+  ((_type*)checked_xcalloc((_num),sizeof(_type),1))
 #define XFREE(_ptr)						\
         do { if (_ptr) { free (_ptr); _ptr = 0; } } while (0)
 

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -35,17 +35,19 @@ extern void free (void*);
 extern void set_alloc_limit (size_t size);
 extern size_t get_alloc_limit();
 extern void alloc_limit_assert (char *fn_name, size_t size);
-extern void* checked_xmalloc (size_t num, size_t size);
-extern void* xmalloc (size_t num, size_t size);
+extern void* checked_xmalloc (size_t num, size_t size, size_t extra);
+extern void* xmalloc (size_t num, size_t size, size_t extra);
 extern void* checked_xcalloc (size_t num, size_t size, size_t extra);
 extern void* xcalloc (size_t num, size_t size, size_t extra);
 
 #define XMALLOC(_type,_num)			                \
-        ((_type*)xmalloc((_num), sizeof(_type)))
+  ((_type*)xmalloc((_num), sizeof(_type), 0))
 #define XCALLOC(_type,_num) 				        \
   ((_type*)xcalloc((_num), sizeof (_type), 0))
 #define CHECKED_XMALLOC(_type,_num) 			        \
-        ((_type*)checked_xmalloc((_num),sizeof(_type)))
+  ((_type*)checked_xmalloc((_num),sizeof(_type),0))
+#define CHECKED_XMALLOC_ADDNULL(_type,_num) 			        \
+  ((_type*)checked_xmalloc((_num),sizeof(_type),1))
 #define CHECKED_XCALLOC(_type,_num)			\
   ((_type*)checked_xcalloc((_num),sizeof(_type),0))
 #define CHECKED_XCALLOC_ADDNULL(_type,_num)		\

--- a/src/attr.c
+++ b/src/attr.c
@@ -256,14 +256,13 @@ attr_read (FILE* in)
     attr->type = (type_and_name >> 16);
     attr->name = ((type_and_name << 16) >> 16);
     attr->len = geti32(in);
-    /* Allocate an extra byte for the null terminator. */
+    /* Allocate an extra byte for the null terminator,
+       in case the input lacks it,
+       this avoids strdup() being invoked on possibly non-terminated
+       input later (file.c, file_add_attr()). */
     attr->buf = CHECKED_XCALLOC_ADDNULL(unsigned char, attr->len);
 
     (void)getbuf(in, attr->buf, attr->len);
-    /* Always null terminate, in case the input lacks it,
-       this avoids strdup() being invoked on possibly non-terminated
-       input later (file.c, file_add_attr()). */
-    attr->buf[attr->len]='\0';
 
     checksum = geti16(in);
     if (!check_checksum(attr, checksum))

--- a/src/attr.c
+++ b/src/attr.c
@@ -257,7 +257,7 @@ attr_read (FILE* in)
     attr->name = ((type_and_name << 16) >> 16);
     attr->len = geti32(in);
     /* Allocate an extra byte for the null terminator. */
-    attr->buf = CHECKED_XCALLOC (unsigned char, attr->len + 1);
+    attr->buf = CHECKED_XCALLOC_ADDNULL(unsigned char, attr->len);
 
     (void)getbuf(in, attr->buf, attr->len);
     /* Always null terminate, in case the input lacks it,

--- a/src/attr.c
+++ b/src/attr.c
@@ -256,9 +256,14 @@ attr_read (FILE* in)
     attr->type = (type_and_name >> 16);
     attr->name = ((type_and_name << 16) >> 16);
     attr->len = geti32(in);
-    attr->buf = CHECKED_XCALLOC (unsigned char, attr->len);
+    /* Allocate an extra byte for the null terminator. */
+    attr->buf = CHECKED_XCALLOC (unsigned char, attr->len + 1);
 
     (void)getbuf(in, attr->buf, attr->len);
+    /* Always null terminate, in case the input lacks it,
+       this avoids strdup() being invoked on possibly non-terminated
+       input later (file.c, file_add_attr()). */
+    attr->buf[attr->len]='\0';
 
     checksum = geti16(in);
     if (!check_checksum(attr, checksum))

--- a/src/mapi_attr.c
+++ b/src/mapi_attr.c
@@ -316,8 +316,10 @@ mapi_attr_read (size_t len, unsigned char *buf)
                 }
                 else
                 {
-                    v->data.buf = CHECKED_XMALLOC(unsigned char, v->len);
+		  /* add space for a null terminator, in case of evil input */
+                    v->data.buf = CHECKED_XMALLOC_ADDNULL(unsigned char, v->len);
                     memmove (v->data.buf, buf+idx, v->len);
+		    v->data.buf[v->len] = '\0';
                 }
 
                 idx += pad_to_4byte(v->len);


### PR DESCRIPTION
A buffer read overflow may happen at
[file.c line 236](https://github.com/verdammelt/tnef/blob/75b21463f6dc238a10b8bb49cef6a4eb0716f292/src/file.c#L236) where strdup() is invoked.
strdup() will just search until it finds a null terminator. If there was none, it will continue past the heap allocated memory. (Update 20191110: there is another one in mapi_attr.c, see https://github.com/verdammelt/tnef/pull/40/commits/3ae8b93746aa6403420b9907886993ceaa6705e3)

The effect of this read overflow is that either the
application crashes from a segfault, or "random" data is being
duplicated, the effect of which I do not know. Writing a file with
garbage suffixed to the name, perhaps, but there seem to be some kind of
sanitation in path.c preventing that.

Update: there is another similar situation in mapi_attr.c, also fixed in this pull request.

An example input that triggers the behaviour is base64 encoded here:
```
base64 <mini
eJ8+IjAwATAwMDAEAAAAAAABAAEAATAwMDAIAAAA5AQAAAAAAADoAAEwMDAwGAAAAElQTS5NaWNy
b3NvZnQgTWFpbC5Ob3RlADEIATAwMDAhAAAANDAwMTdGQ0ZEMDgxRDMxMUE3QTUwMDA4QzcxQkNB
OEQAJAcBMDAwMBgAAABJUE0uTWljcm9zb2Z0IE1haWwuTm90ZQAxCAEwMDAwDgAAAM8HCgANABYA
MwAzAAMAbAEBMDAwMA4AAADPBwoADQAWADEACQADAEABATAwMDAKAAAAdHdvIGZpbGVzAI0DATAw
MDACAAAAAgACAAEwMDAwuAUAADgAAAADAP0/5AQAAEAAOQCAgBGw7hW/AR4AMUABAAAAFgAAAHNp
bXBzb25Ad29ybGQuc3RkLmNvbQAAAAMAGkAAAAEAHgAwQAEAAAAWAAAAc2ltcHNvbkB3b3JsZC5z
dGQuY29tAAAAAwAZQAAAAQADAN4/r28AAB4AcAABAAAACgAAAHR3byBmaWxlcwAAAAIBcQABAAAA
FgAAAAG/Fe8OHc9/AUGB0BHTp6UACMcbyo0AAB4A/lcBAAAAFQAAAE5BSVNDQU5ORURQT1NUT0ZG
SUNFAAAAAAsA8hABAAAAAgHzPwEAAAAAAAAAAgH0PwEAAAAAAAAAAgE/AAEAAABRAAAAAAAAANyn
QMjAQhAatLkIACsv4YIBAAAAAAAAAC9PPUNPTVBVV0FSRS9PVT1OVU1FR0EgTEFCL0NOPVJFQ0lQ
SUVOVFMvQ049TVNJTVBTT04AAAAAHgB1AAEAAAAFAAAAU01UUAAAAAAeAHYAAQAAABgAAABtYXJr
LnNpbXBzb25AbnVtZWdhLmNvbQAeAEAAAQAAAA4AAABTaW1wc29uLCBNYXJrAAAAHgA0QAEAAAAJ
AAAATVNJTVBTT04AAAAAAgFRAAEAAAA4AAAARVg6L089Q09NUFVXQVJFL09VPU5VTUVHQSBMQUIv
Q049UkVDSVBJRU5UUy9DTj1NU0lNUFNPTgADABtAAAAAAAIBQwABAAAAUQAAAAAAAADcp0DIwEIQ
GrS5CAArL+GCAQAAAAAAAAAvTz1DT01QVVdBUkUvT1U9TlVNRUdBIExBQi9DTj1SRUNJUElFTlRT
L0NOPU1TSU1QU09OAAAAAB4AdwABAAAABQAAAFNNVFAAAAAAHgB4AAEAAAAYAAAAbWFyay5zaW1w
c29uQG51bWVnYS5jb20AHgBEAAEAAAAOAAAAU2ltcHNvbiwgTWFyawAAAB4ANUABAAAACQAAAE1T
SU1QU09OAAAAAAIBUgABAAAAOAAAAEVYOi9PPUNPTVBVV0FSRS9PVT1OVU1FR0EgTEFCL0NOPVJF
Q0lQSUVOVFMvQ049TVNJTVBTT04AAwAcQAAAAAALAFcAAQAAAAsAWAAAAAAACwBZAAEAAAACAUcA
AQAAAAAAAAACAfk/AQAAAEAAAAAAAAAAgSsfpL6jEBmdbgDdAQ9UAgAAAQBNYXJrIFNpbXBzb24A
U01UUABzaW1wc29uQHdvcmxkLnN0ZC5jb20AHgD4PwEAAAANAAAATWFyayBTaW1wc29uAAAAAB4A
OEABAAAAFgAAAHNpbXBzb25Ad29ybGQuc3RkLmNvbQAAAAIB+z8BAAAAUQAAAAAAAADcp0DIwEIQ
GrS5CAArL+GCAQAAAAAAAAAvTz1DT01QVVdBUkUvT1U9TlVNRUdBIExBQi9DTj1SRUNJUElFTlRT
L0NOPU1TSU1QU09OAAAAAB4A+j8BAAAADgAAAFNpbXBzb24sIE1hcmsAAAAeADlAAQAAAAkAAABN
U0lNUFNPTgAAAABAAAcwuPYdDu8VvwFAAAgwmMHyEO8VvwEeAD0AAQAAAAEAAAAAAAAAHgAdDgEA
AAAKAAAAdHdvIGZpbGVzAAAAAgHUPwEAAAAAAAAAHgA1EAEAAAAyAAAAPDE0MzQxLjE3NTczLjU2
MDc2MS4zNjg1MTJAbG9jYWxob3N0LmxvY2FsZG9tYWluPgAAAB4AORABAAAAAQAAAAAAAAAeADYQ
AQAAAAEAAAAAAAAAAgFoQAEAAAAAAAAAAgFpQAEAAAAAAAAAAwA2AAAAAAALACkAAAAAAAsAIwAA
AAAAAwAGEAAAAAADAAcQAAAAAAMAEBAAAAAAAwAREAAAAAAeAAgQAQAAAAEAAAAAAAAAAgF/AAEA
AAAyAAAAPDE0MzQxLjE3NTczLjU2MDc2MS4zNjg1MTJAbG9jYWxob3N0LmxvY2FsZG9tYWluPgAA
AFUdAgKQMDAOAAAAAQD/////IAAgAAAAAAA9BAIwMDAwDgAAAM8HCgANABYAMwAuAAMAZwECMDAw
MA4AAADPBwoADQAWADMALgADAGcBAjAwMDAIAAAAQVVUSE9SUwAmAgIQgDAw9AAAAAogICAgICAg
ICAgICAgICAgICAgICAgICAgICAgICBBdXRob3JzIG9mIHRuZWYKICAgICAgICAgICAgICAgICAg
ICAgICAgICAgICAgPT09PT09PT09PT09PT09CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
ICAgICAgICAKKiBNYXJrIFNpbXBzb24gICAgICAgICAgICBkYW1uZWRAd29ybGQuc3RkLmNvbQoK
TWFueSB0aGFuayBnbyB0byB0aGUgb3JpZ2luYWwgYXV0aG9yOiBUaG9tYXMgQm9sbCAodGJAYm9s
bC5jaCkuCgrTOQ==
```

To prove the bug, run
```shell
base64 -d >mini # paste input from above
valgrind src/tnef mini
```

and get (source lines are not accurate, I ran it on the patched version, with the fix disabled) 
```
paul@tonfisk:~/code/delaktig/tnef$ valgrind src/tnef  mini
==506== Memcheck, a memory error detector
==506== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==506== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==506== Command: src/tnef mini
==506== 
==506== Invalid read of size 1
==506==    at 0x4C32D04: strlen (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==506==    by 0x4ED99AD: strdup (strdup.c:41)
==506==    by 0x10B058: file_add_attr (file.c:236)
==506==    by 0x10CD5E: parse_file (tnef.c:334)
==506==    by 0x10990C: main (main.c:380)
==506==  Address 0x522f4a4 is 0 bytes after a block of size 244 alloc'd
==506==    at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==506==    by 0x10A6A3: attr_read (attr.c:260)
==506==    by 0x10CD28: read_object (tnef.c:70)
==506==    by 0x10CD28: parse_file (tnef.c:277)
==506==    by 0x10990C: main (main.c:380)
==506== 
==506== Invalid read of size 1
==506==    at 0x4C36788: memmove (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==506==    by 0x10B058: file_add_attr (file.c:236)
==506==    by 0x10CD5E: parse_file (tnef.c:334)
==506==    by 0x10990C: main (main.c:380)
==506==  Address 0x522f4a4 is 0 bytes after a block of size 244 alloc'd
==506==    at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==506==    by 0x10A6A3: attr_read (attr.c:260)
==506==    by 0x10CD28: read_object (tnef.c:70)
==506==    by 0x10CD28: parse_file (tnef.c:277)
==506==    by 0x10990C: main (main.c:380)
==506== 
%0A                              Authors of tnef%0A                              ===============%0A                                     %0A%2A Mark Simpson            damned@world.std.com%0A%0AMany thank go to the original author%3A Thomas Boll (tb@boll.ch).%0A%0A: File name too long
==506== 
==506== HEAP SUMMARY:
==506==     in use at exit: 1,395 bytes in 6 blocks
==506==   total heap usage: 42 allocs, 36 frees, 10,971 bytes allocated
==506== 
==506== LEAK SUMMARY:
==506==    definitely lost: 0 bytes in 0 blocks
==506==    indirectly lost: 0 bytes in 0 blocks
==506==      possibly lost: 0 bytes in 0 blocks
==506==    still reachable: 1,395 bytes in 6 blocks
==506==         suppressed: 0 bytes in 0 blocks
==506== Rerun with --leak-check=full to see details of leaked memory
==506== 
==506== For counts of detected and suppressed errors, rerun with: -v
==506== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```