### PR TITLE
fix shift into sign bit

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -31,10 +31,8 @@
 /* Needed to transform char buffers into little endian numbers */
 uint32 GETINT32(unsigned char *p)
 {
-    return (uint32)((uint8)(p)[0]           \
-                    +((uint8)(p)[1]<<8)     \
-                    +((uint8)(p)[2]<<16)    \
-                    +((uint8)(p)[3]<<24));
+  uint8* q=(uint8*)p;
+  return q[0] + (q[1]<<8) + (q[2]<<16)+ (((uint32)q[3])<<24);
 }
 
 uint16 GETINT16 (unsigned char* p)


### PR DESCRIPTION
The intermediate uint8 is implicitly promoted to an int before shifting,
shifting into the sign bit is undefined behaviour in C.

The compiler does not seem to exploit this, for gcc at least, the
generated code is identical.