### PR TITLE
Mingw compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@ AC_CHECK_SIZEOF(int)
 
 dnl check for library functions
 AC_REPLACE_FUNCS(strdup getopt_long basename)
-AC_CHECK_FUNCS(strrchr memmove memset strtoul)
+AC_CHECK_FUNCS(strrchr memmove memset strtoul index rindex)
 AC_FUNC_VPRINTF
 AC_FUNC_MALLOC
 

--- a/src/path.c
+++ b/src/path.c
@@ -35,6 +35,14 @@
 #include "path.h"
 #include "debug.h"
 
+#if !HAVE_RINDEX && HAVE_STRRCHR
+#  define rindex strrchr
+#endif
+
+#if !HAVE_INDEX
+#  define index strchr
+#endif
+
 /* concatenates fname1 with fname2 to make a pathname, adds '/' as needed */
 /* strips trailing '/' */
 

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -27,6 +27,3 @@ check_file () {
     check_exists $1
     check_test_full $1 $1.baseline $1.diff
 }
-
-    
-        

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -5,7 +5,7 @@
 #   baseline
 #   diff
 check_test_full () {
-    diff "$1" "$2" > "$3" 2>&1
+    diff --ignore-space-change "$1" "$2" > "$3" 2>&1
     if [ $? -ne 0 ]; then
         echo "\'diff \"$1\" \"$2\" > \"$3\"\' -- Test Failed!"
         exit 1


### PR DESCRIPTION
`tnef` compiles with MSYS2, but fails with MinGW. If fails to link with: `undefined reference to 'rindex'` and `undefined reference to 'index'`. Which makes sense, since mingw links against `msvcrt.dll` and it lacks those symbols.

Additionally all tests in `make check` fail on mingw, because of `\CR\LF` line endings.

These patches attempt to address these issues.